### PR TITLE
Update nginx.conf

### DIFF
--- a/container-template/proxy/nginx.conf
+++ b/container-template/proxy/nginx.conf
@@ -1,7 +1,7 @@
 events { worker_connections 2048; }
 
 http {
-
+    client_max_body_size 1024M;
     # invokeai
     server {
         listen 9091;
@@ -27,7 +27,7 @@ http {
     # Fast Stable Diffusion + web UI + Comfy UI
     server {
         listen 3001;
-	client_max_body_size 1024M;
+		
         location /ws {
             proxy_http_version 1.1;
             proxy_set_header Accept-Encoding gzip;

--- a/container-template/proxy/nginx.conf
+++ b/container-template/proxy/nginx.conf
@@ -27,7 +27,7 @@ http {
     # Fast Stable Diffusion + web UI + Comfy UI
     server {
         listen 3001;
-
+	client_max_body_size 1024M;
         location /ws {
             proxy_http_version 1.1;
             proxy_set_header Accept-Encoding gzip;


### PR DESCRIPTION
allows /upload of at least 1GB. This could probably be increased.

File uploads were failing with a HTTP 413 even when we bypass the cloudflare reverse proxy this setting enables files upload to all routes on the webUI. If a file larger then the max body size is uploaded, the stream is cut off when it reach the max body size

Tested on slmagus/stable-diff:dev which required some hacks to bypass the lack of a proxy image. This merge assumes the updates will be included when --from=proxy is rebuilt.