### PR TITLE
Fix rsync command for ComfyUI so that people can update ComfyUI using a git pull

### DIFF
--- a/official-templates/stable-diffusion-comfyui/pre_start.sh
+++ b/official-templates/stable-diffusion-comfyui/pre_start.sh
@@ -2,7 +2,7 @@
 
 export PYTHONUNBUFFERED=1
 source /venv/bin/activate
-rsync -au --remove-source-files /ComfyUI/* /workspace/ComfyUI
+rsync -au --remove-source-files /ComfyUI/ /workspace/ComfyUI/
 ln -s /comfy-models/* /workspace/ComfyUI/models/checkpoints/
 
 cd /workspace/ComfyUI


### PR DESCRIPTION
The ComfyUI template is missing the `.git` directory from `/workspace` because the rsync command only syncs `/ComfyUI/*` instead of all of the files within `/ComfyUI`.

The updated rsync command will ensure that the `.git` directory is rsynced and thus allow users to do `git pull` so that they can update their ComfyUI to the latest version.