### PR TITLE
Change behaviour on how ssh keys are added to authorized_keys

### DIFF
--- a/container-template/start.sh
+++ b/container-template/start.sh
@@ -26,7 +26,7 @@ setup_ssh() {
     if [[ $PUBLIC_KEY ]]; then
         echo "Setting up SSH..."
         mkdir -p ~/.ssh
-        echo "$PUBLIC_KEY" >> ~/.ssh/authorized_keys
+        echo "$PUBLIC_KEY" > ~/.ssh/authorized_keys
         chmod 700 -R ~/.ssh
 
          if [ ! -f /etc/ssh/ssh_host_rsa_key ]; then


### PR DESCRIPTION
This PR updates the startup script to overwrite the `authorized_keys` file with the provided `PUBLIC_KEY` environment variable, rather than appending to it. This change ensures that only the specified key will be authorized and does not accumulate keys from successive reboots.