### PR TITLE
Add runpod/cuda image (12.4, 12.3, 12.2, 12.1, 11.8)

### DIFF
--- a/official-templates/cuda/Dockerfile
+++ b/official-templates/cuda/Dockerfile
@@ -1,0 +1,66 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG PYTHON_VERSION
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Set environment variables
+ENV DEBIAN_FRONTEND=noninteractive
+ENV SHELL=/bin/bash
+
+# Set the working directory
+WORKDIR /
+
+# Create workspace directory
+RUN mkdir /workspace
+
+# Update, upgrade, install packages and clean up
+RUN apt-get update --yes && \
+    apt-get upgrade --yes && \
+    apt install --yes --no-install-recommends git wget curl bash libgl1 software-properties-common openssh-server nginx && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt install "python${PYTHON_VERSION}-dev" "python${PYTHON_VERSION}-venv" -y --no-install-recommends && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
+
+
+# Set up Python and pip
+RUN ln -s /usr/bin/python${PYTHON_VERSION} /usr/bin/python && \
+    rm /usr/bin/python3 && \
+    ln -s /usr/bin/python${PYTHON_VERSION} /usr/bin/python3 && \
+    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+    python get-pip.py
+
+
+RUN pip install --upgrade --no-cache-dir pip
+RUN pip install --upgrade --no-cache-dir jupyterlab ipywidgets jupyter-archive jupyter_contrib_nbextensions
+
+# Set up Jupyter Notebook
+RUN pip install notebook==6.5.5
+RUN jupyter contrib nbextension install --user && \
+    jupyter nbextension enable --py widgetsnbextension
+
+# Remove existing SSH host keys
+RUN rm -f /etc/ssh/ssh_host_*
+
+# NGINX Proxy
+COPY --from=proxy nginx.conf /etc/nginx/nginx.conf
+COPY --from=proxy readme.html /usr/share/nginx/html/readme.html
+
+# Copy the README.md
+COPY README.md /usr/share/nginx/html/README.md
+
+# Start Scripts
+COPY --from=scripts start.sh /
+RUN chmod +x /start.sh
+
+# Welcome Message
+COPY --from=logo runpod.txt /etc/runpod.txt
+RUN echo 'cat /etc/runpod.txt' >> /root/.bashrc
+RUN echo 'echo -e "\nFor detailed documentation and guides, please visit:\n\033[1;34mhttps://docs.runpod.io/\033[0m and \033[1;34mhttps://blog.runpod.io/\033[0m\n\n"' >> /root/.bashrc
+
+# Set the default command for the container
+CMD [ "/start.sh" ]

--- a/official-templates/cuda/README.md
+++ b/official-templates/cuda/README.md
@@ -1,0 +1,7 @@
+## Build Options
+
+To build with default options, run `docker buildx bake`, to build a specific target, run `docker buildx bake <target>`.
+
+## Ports
+
+- 22/tcp (SSH)

--- a/official-templates/cuda/docker-bake.hcl
+++ b/official-templates/cuda/docker-bake.hcl
@@ -3,7 +3,8 @@ group "default" {
         "11.8.0-devel-ubuntu22.04",
         "12.1.1-devel-ubuntu22.04",
         "12.2.2-devel-ubuntu22.04",
-        "12.3.2-devel-ubuntu22.04"
+        "12.3.2-devel-ubuntu22.04",
+        "12.4.1-devel-ubuntu22.04"
     ]
 }
 
@@ -63,6 +64,20 @@ target "12.3.2-devel-ubuntu22.04" {
     }
     args = {
         BASE_IMAGE = "nvidia/cuda:12.3.2-devel-ubuntu22.04"
+        PYTHON_VERSION = "3.10"
+    }
+
+
+target "12.4.1-devel-ubuntu22.04" {
+    dockerfile = "Dockerfile"
+    tags = ["runpod/cuda:12.4.1-devel-ubuntu22.04"]
+    contexts = {
+        scripts = "../../container-template"
+        proxy = "../../container-template/proxy"
+        logo = "../../container-template"
+    }
+    args = {
+        BASE_IMAGE = "nvidia/cuda:12.4.1-devel-ubuntu22.04"
         PYTHON_VERSION = "3.10"
     }
 }

--- a/official-templates/cuda/docker-bake.hcl
+++ b/official-templates/cuda/docker-bake.hcl
@@ -1,0 +1,68 @@
+group "default" {
+    targets = [
+        "11.8.0-devel-ubuntu22.04",
+        "12.1.1-devel-ubuntu22.04",
+        "12.2.2-devel-ubuntu22.04",
+        "12.3.2-devel-ubuntu22.04"
+    ]
+}
+
+
+target "11.8.0-devel-ubuntu22.04" {
+    dockerfile = "Dockerfile"
+    tags = ["runpod/cuda:11.8.0-devel-ubuntu22.04"]
+    contexts = {
+        scripts = "../../container-template"
+        proxy = "../../container-template/proxy"
+        logo = "../../container-template"
+    }
+    args = {
+        BASE_IMAGE = "nvidia/cuda:11.8.0-devel-ubuntu22.04"
+        PYTHON_VERSION = "3.10"
+    }
+}
+
+
+target "12.1.1-devel-ubuntu22.04" {
+    dockerfile = "Dockerfile"
+    tags = ["runpod/cuda:12.1.1-devel-ubuntu22.04"]
+    contexts = {
+        scripts = "../../container-template"
+        proxy = "../../container-template/proxy"
+        logo = "../../container-template"
+    }
+    args = {
+        BASE_IMAGE = "nvidia/cuda:12.1.1-devel-ubuntu22.04"
+        PYTHON_VERSION = "3.10"
+    }
+}
+
+
+target "12.2.2-devel-ubuntu22.04" {
+    dockerfile = "Dockerfile"
+    tags = ["runpod/cuda:12.2.2-devel-ubuntu22.04"]
+    contexts = {
+        scripts = "../../container-template"
+        proxy = "../../container-template/proxy"
+        logo = "../../container-template"
+    }
+    args = {
+        BASE_IMAGE = "nvidia/cuda:12.2.2-devel-ubuntu22.04"
+        PYTHON_VERSION = "3.10"
+    }
+}
+
+
+target "12.3.2-devel-ubuntu22.04" {
+    dockerfile = "Dockerfile"
+    tags = ["runpod/cuda:12.3.2-devel-ubuntu22.04"]
+    contexts = {
+        scripts = "../../container-template"
+        proxy = "../../container-template/proxy"
+        logo = "../../container-template"
+    }
+    args = {
+        BASE_IMAGE = "nvidia/cuda:12.3.2-devel-ubuntu22.04"
+        PYTHON_VERSION = "3.10"
+    }
+}


### PR DESCRIPTION
We don't have any cuda 12.2 and 12.3 images that users can SSH into and use the Jupyter notebook functionality with, while the demand for those cuda versions keeps rising