### PR TITLE
Add ROCm PyTorch Official RunPod Image

### DIFF
--- a/official-templates/pytorch/Dockerfile.rocm
+++ b/official-templates/pytorch/Dockerfile.rocm
@@ -1,0 +1,56 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Set environment variables
+ENV DEBIAN_FRONTEND=noninteractive
+ENV SHELL=/bin/bash
+
+# Set the working directory
+WORKDIR /
+
+# Create workspace directory
+RUN mkdir /workspace
+
+# Update, upgrade, install packages and clean up
+RUN apt-get update --yes && \
+    apt-get upgrade --yes && \
+    apt install --yes --no-install-recommends git wget curl bash libgl1 software-properties-common openssh-server nginx && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
+
+# Upgrade pip
+RUN pip install --upgrade --no-cache-dir pip
+
+# Install additional Python packages
+RUN pip install --upgrade --no-cache-dir jupyterlab ipywidgets jupyter-archive jupyter_contrib_nbextensions
+
+# Set up Jupyter Notebook
+RUN pip install notebook==6.5.5
+RUN jupyter contrib nbextension install --user && \
+    jupyter nbextension enable --py widgetsnbextension
+
+# Remove existing SSH host keys
+RUN rm -f /etc/ssh/ssh_host_*
+
+# NGINX Proxy
+COPY --from=proxy nginx.conf /etc/nginx/nginx.conf
+COPY --from=proxy readme.html /usr/share/nginx/html/readme.html
+
+# Copy the README.md
+COPY README.md /usr/share/nginx/html/README.md
+
+# Start Scripts
+COPY --from=scripts start.sh /
+RUN chmod +x /start.sh
+
+# Welcome Message
+COPY --from=logo runpod.txt /etc/runpod.txt
+RUN echo 'cat /etc/runpod.txt' >> /root/.bashrc
+RUN echo 'echo -e "\nFor detailed documentation and guides, please visit:\n\033[1;34mhttps://docs.runpod.io/\033[0m and \033[1;34mhttps://blog.runpod.io/\033[0m\n\n"' >> /root/.bashrc
+
+# Set the default command for the container
+CMD [ "/start.sh" ]

--- a/official-templates/pytorch/docker-bake.hcl
+++ b/official-templates/pytorch/docker-bake.hcl
@@ -5,6 +5,7 @@ group "default" {
         "201-py310-cuda1180-devel-ubuntu2204",
         "210-py310-cuda1180-devel-ubuntu2204",
         "211-py310-cuda1211-devel-ubuntu2204",
+        "212-py310-rocm61-ubuntu2204",
         "221-py310-cuda1211-devel-ubuntu2204"
     ]
 }
@@ -86,6 +87,19 @@ target "211-py310-cuda1211-devel-ubuntu2204" {
         BASE_IMAGE = "nvidia/cuda:12.1.1-devel-ubuntu22.04"
         PYTHON_VERSION = "3.10"
         TORCH = "torch==2.1.1 torchvision==0.16.1 torchaudio==2.1.1 --index-url https://download.pytorch.org/whl/cu121"
+    }
+}
+
+target "212-py310-rocm61-ubuntu2204" {
+    dockerfile = "Dockerfile.rocm"
+    tags = ["runpod/pytorch:2.1.2-py3.10-rocm6.1-ubuntu22.04"]
+    contexts = {
+        scripts = "../../container-template"
+        proxy = "../../container-template/proxy"
+        logo = "../../container-template"
+    }
+    args = {
+        BASE_IMAGE = "rocm/pytorch:rocm6.1_ubuntu22.04_py3.10_pytorch_2.1.2"
     }
 }
 


### PR DESCRIPTION
Added official PyTorch image with:
- ROCm 6.1 
- PyTorch 2.1.2 
- Ubuntu 22.04

Builds successfully, waiting for AMD access to test.