### PR TITLE
Add runpod/base 12.1.1, 12.2.2, 12.3.2, 12.4.1

### DIFF
--- a/official-templates/base/docker-bake.hcl
+++ b/official-templates/base/docker-bake.hcl
@@ -3,7 +3,7 @@ variable "RELEASE" {
 }
 
 group "default" {
-    targets = ["cpu", "11-1-1", "11-8-0", "12-1-0", "12-2-0"]
+    targets = ["cpu", "11-1-1", "11-8-0", "12-1-0", "12-1-1", "12-2-0", "12-2-2", "12-3-2", "12-4-1"]
 }
 
 target "cpu" {
@@ -62,6 +62,20 @@ target "12-1-0" {
     }
 }
 
+target "12-1-1" {
+    dockerfile = "Dockerfile"
+    tags = ["runpod/base:${RELEASE}-cuda12.1.0"]
+    contexts = {
+        scripts = "../../container-template"
+        proxy = "../../container-template/proxy"
+        logo = "../../container-template"
+    }
+    args = {
+        BASE_RELEASE_VERSION = "${RELEASE}"
+        BASE_IMAGE = "nvidia/cuda:12.1.1-devel-ubuntu22.04"
+    }
+}
+
 target "12-2-0" {
     dockerfile = "Dockerfile"
     tags = ["runpod/base:${RELEASE}-cuda12.2.0"]
@@ -73,5 +87,47 @@ target "12-2-0" {
     args = {
         BASE_RELEASE_VERSION = "${RELEASE}"
         BASE_IMAGE = "nvidia/cuda:12.2.0-devel-ubuntu22.04"
+    }
+}
+
+target "12-2-2" {
+    dockerfile = "Dockerfile"
+    tags = ["runpod/base:${RELEASE}-cuda12.2.2"]
+    contexts = {
+        scripts = "../../container-template"
+        proxy = "../../container-template/proxy"
+        logo = "../../container-template"
+    }
+    args = {
+        BASE_RELEASE_VERSION = "${RELEASE}"
+        BASE_IMAGE = "nvidia/cuda:12.2.2-devel-ubuntu22.04"
+    }
+}
+
+target "12-3-2" {
+    dockerfile = "Dockerfile"
+    tags = ["runpod/base:${RELEASE}-cuda12.3.2"]
+    contexts = {
+        scripts = "../../container-template"
+        proxy = "../../container-template/proxy"
+        logo = "../../container-template"
+    }
+    args = {
+        BASE_RELEASE_VERSION = "${RELEASE}"
+        BASE_IMAGE = "nvidia/cuda:12.3.2-devel-ubuntu22.04"
+    }
+}
+
+target "12-4-1" {
+    dockerfile = "Dockerfile"
+    tags = ["runpod/base:${RELEASE}-cuda12.4.1"]
+    contexts = {
+        scripts = "../../container-template"
+        proxy = "../../container-template/proxy"
+        logo = "../../container-template"
+    }
+    args = {
+        BASE_RELEASE_VERSION = "${RELEASE}"
+        BASE_IMAGE = "nvidia/cuda:12.4.1-devel-ubuntu22.04"
     }
 }


### PR DESCRIPTION
Latest relevant CUDA versions.

Also, the only available 12.1 runpod/base image is based on 12.1.0, which was deprecated by NVIDIA - this adds 12.1.1.