### PR TITLE
Added images for pytorch 2.3.0 and python 3.12, added jupyterlab to new image and fileexplorer

### DIFF
--- a/container-template/start.sh
+++ b/container-template/start.sh
@@ -81,6 +81,14 @@ start_jupyter() {
     fi
 }
 
+start_filebrowser() {
+    if [[ $INCLUDE_FILEBROWSER == "yes" ]]; then
+        echo "starting filebrowser..."
+        nohup filebrowser --address=0.0.0.0 --port=4040 --root=/ --noauth &
+        echo "File browser started"
+    fi
+}
+
 # ---------------------------------------------------------------------------- #
 #                               Main Program                                   #
 # ---------------------------------------------------------------------------- #
@@ -93,6 +101,7 @@ echo "Pod Started"
 
 setup_ssh
 start_jupyter
+start_filebrowser
 export_env_vars
 
 execute_script "/post_start.sh" "Running post-start script..."

--- a/official-templates/pytorch/Dockerfile
+++ b/official-templates/pytorch/Dockerfile
@@ -4,11 +4,21 @@ FROM ${BASE_IMAGE}
 ARG TORCH
 ARG PYTHON_VERSION
 
+# Set default value for JUPYTER_LAB_OR_NOTEBOOK
+ARG JUPYTER_LAB_OR_NOTEBOOK=notebook
+ARG INCLUDE_FILEBROWSER=no
+
+
+
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 ENV SHELL=/bin/bash
+
+# Use the argument to set the environment variable
+ENV JUPYTER_LAB_OR_NOTEBOOK=${JUPYTER_LAB_OR_NOTEBOOK}
+ENV INCLUDE_FILEBROWSER=${INCLUDE_FILEBROWSER}
 
 # Set the working directory
 WORKDIR /
@@ -44,10 +54,22 @@ RUN pip install --upgrade --no-cache-dir pip
 RUN if [ -n "${TORCH}" ]; then pip install --upgrade --no-cache-dir ${TORCH}; fi 
 RUN pip install --upgrade --no-cache-dir jupyterlab ipywidgets jupyter-archive jupyter_contrib_nbextensions
 
-# Set up Jupyter Notebook
-RUN pip install notebook==6.5.5
-RUN jupyter contrib nbextension install --user && \
-    jupyter nbextension enable --py widgetsnbextension
+
+
+# Conditional installation based on the value of JUPYTER_LAB_OR_NOTEBOOK
+# Jupyter notebook version 6.5.5 does not work with the latest version of python
+RUN if [ "$JUPYTER_LAB_OR_NOTEBOOK" = "lab" ]; then \
+      pip install jupyterlab; \
+    else \
+      pip install notebook==6.5.5 && \
+      jupyter contrib nbextension install --user && \
+      jupyter nbextension enable --py widgetsnbextension; \
+    fi
+
+## install filebrowser if wanted
+RUN if [ "$INCLUDE_FILEBROWSER" = "yes" ]; then \
+        curl -fsSL https://raw.githubusercontent.com/filebrowser/get/master/get.sh | bash; \
+    fi
 
 # Remove existing SSH host keys
 RUN rm -f /etc/ssh/ssh_host_*
@@ -70,3 +92,4 @@ RUN echo 'echo -e "\nFor detailed documentation and guides, please visit:\n\033[
 
 # Set the default command for the container
 CMD [ "/start.sh" ]
+

--- a/official-templates/pytorch/docker-bake.hcl
+++ b/official-templates/pytorch/docker-bake.hcl
@@ -143,6 +143,7 @@ target "220-py310-cuda1211-devel-ubuntu2204" {
 target "221-py310-cuda1211-devel-ubuntu2204" {
     dockerfile = "Dockerfile"
     tags = ["${PUBLISHER}/pytorch:2.2.1-py3.10-cuda12.1.1-devel-ubuntu22.04"]
+    platforms = ["linux/amd64"]
     contexts = {
         scripts = "../../container-template"
         proxy = "../../container-template/proxy"
@@ -152,6 +153,24 @@ target "221-py310-cuda1211-devel-ubuntu2204" {
         BASE_IMAGE = "nvidia/cuda:12.1.1-devel-ubuntu22.04"
         PYTHON_VERSION = "3.10"
         TORCH = "torch torchvision torchaudio"
+    }
+}
+
+target "230-py312-cuda1241-devel-ubuntu2204" {
+    dockerfile = "Dockerfile"
+    tags = ["${PUBLISHER}/pytorch:2.3.0-py3.12-cuda12.4.1-devel-ubuntu22.04"]
+    platforms = ["linux/amd64"]
+    contexts = {
+        scripts = "../../container-template"
+        proxy = "../../container-template/proxy"
+        logo = "../../container-template"
+    }
+    args = {
+        BASE_IMAGE = "nvidia/cuda:12.4.1-devel-ubuntu22.04"
+        PYTHON_VERSION = "3.12"
+        TORCH = "torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0"
+        JUPYTER_LAB_OR_NOTEBOOK = "lab"
+        INCLUDE_FILEBROWSER = "yes"
     }
 }
 


### PR DESCRIPTION
This pull request makes the following changes

* Adds a new docker image for pytorch via docker-bake.hcl with **Python 3.12** and **Pytorch 2.3.0** in the pytorch container (along with updated torchaudio and torchvision suppliments)
* Adds a **file explorer** to the new docker image
* modifies the dockerfile to make sure that the file explorer is only added to the newer pytorch image
* modifies the dockerfile to **install jupyterlab instead of jupyter** in the newer image since the older jupyter version is no longer working along side python 3.12

This docker image can be found at https://hub.docker.com/repository/docker/riversnow/pytorch/general for quick testing purposes if required

Let me know if any further changes are needed here