### PR TITLE
Reintroduce post_start.sh

### DIFF
--- a/official-templates/base/Dockerfile
+++ b/official-templates/base/Dockerfile
@@ -108,6 +108,7 @@ COPY README.md /usr/share/nginx/html/README.md
 
 # Start Script
 COPY --from=scripts --chmod=755 start.sh /
+COPY --from=scripts --chmod=755 post_start.sh /
 
 # Welcome Message
 COPY --from=logo runpod.txt /etc/runpod.txt

--- a/official-templates/shared/versions.hcl
+++ b/official-templates/shared/versions.hcl
@@ -1,4 +1,4 @@
-RELEASE_VERSION = "1.0.2"
+RELEASE_VERSION = "1.0.3"
 
 variable "RELEASE_SUFFIX" {
   default = "" # Set by CI, not used by humans.


### PR DESCRIPTION
Adding additional setup steps to images is harder without being able to reference environment variables in them, so I think it's reasonable to put a script we can hook to do stuff after that back in this flow