### PR TITLE
fix: override NVIDIA entrypoint in autoresearch image

### DIFF
--- a/official-templates/autoresearch/Dockerfile
+++ b/official-templates/autoresearch/Dockerfile
@@ -22,3 +22,7 @@ RUN uv run prepare.py
 # On first boot: copy source files to /workspace (lightweight, persists edits)
 # and symlink .venv back to /opt (12GB, stays on fast container layer)
 COPY pre_start.sh /pre_start.sh
+
+# Override the NVIDIA CUDA entrypoint which blocks boot on hosts with older
+# drivers (e.g. driver 550 only supports CUDA 12.4, but this image has 12.8).
+ENTRYPOINT ["/start.sh"]


### PR DESCRIPTION
## Summary

- Adds `ENTRYPOINT ["/start.sh"]` to the autoresearch Dockerfile only
- Overrides the inherited `nvidia_entrypoint.sh` which kills the container on hosts with older NVIDIA drivers (550 = CUDA 12.4 max, but this image needs CUDA 12.8)
- Scoped to autoresearch — does not touch the base image or affect other templates

## Context

The autoresearch template (`x7o8gn1p4f`) enters an undebuggable boot loop on RunPod machines with driver <570. The NVIDIA entrypoint fails the CUDA compatibility check and exits before `/start.sh` runs. No logs, no SSH, just 0 uptime forever.

This is the same approach ComfyUI uses — its image already has `ENTRYPOINT ["/start.sh"]`.

Replaces #112 which tried to fix this in the base image but would break child images that override CMD.

## Test plan

- [ ] Rebuild autoresearch image from this branch
- [ ] Deploy on RTX 4090 community cloud (mixed driver versions)
- [ ] Verify container boots, SSH connects, `/workspace/autoresearch` populated
- [ ] Verify `torch.cuda.is_available()` returns True
- [ ] Verify other templates (ComfyUI, PyTorch) are unaffected

Made with [Cursor](https://cursor.com)