### PR TITLE
Add PyTorch version verification to prevent silent pip fallback

### DIFF
--- a/official-templates/pytorch/Dockerfile
+++ b/official-templates/pytorch/Dockerfile
@@ -5,3 +5,18 @@ ARG WHEEL_SRC
 ARG TORCH
 
 RUN python -m pip install --resume-retries 3 --no-cache-dir --upgrade ${TORCH} --index-url https://download.pytorch.org/whl/cu${WHEEL_SRC}
+
+# Verify that the installed torch version matches what was requested.
+# pip silently falls back to older versions when wheels are missing from an index,
+# which has caused B200 GPUs to be unusable (sm_100 not supported by older PyTorch).
+# See: https://github.com/runpod/containers/issues/114
+RUN EXPECTED_TORCH=$(echo "${TORCH}" | grep -oP 'torch==\K[0-9]+\.[0-9]+\.[0-9]+') && \
+    INSTALLED_TORCH=$(python -c "import torch; print(torch.__version__.split('+')[0])") && \
+    if [ "$EXPECTED_TORCH" != "$INSTALLED_TORCH" ]; then \
+        echo "ERROR: PyTorch version mismatch!" >&2; \
+        echo "  Expected: ${EXPECTED_TORCH}" >&2; \
+        echo "  Installed: ${INSTALLED_TORCH}" >&2; \
+        echo "  Wheel source: cu${WHEEL_SRC}" >&2; \
+        echo "  Check that wheels exist at: https://download.pytorch.org/whl/cu${WHEEL_SRC}/torch/" >&2; \
+        exit 1; \
+    fi


### PR DESCRIPTION
## Summary

Adds a build-time verification step to the PyTorch Dockerfile that fails the build if the installed torch version does not match the requested version. This prevents pip from silently falling back to older PyTorch versions when wheels are missing from a CUDA-specific index.

## Problem

The current Dockerfile installs PyTorch via:

```dockerfile
RUN python -m pip install ... ${TORCH} --index-url https://download.pytorch.org/whl/cu${WHEEL_SRC}
```

When wheels don't exist at the specified index (e.g. `cu128` wheels for torch 2.8.0 were not published at the time of the last image build), **pip silently installs an older version** instead of failing. This caused:

- The `runpod/pytorch:1.0.2-cu1281-torch280-ubuntu2404` template (labeled "PyTorch 2.8.0") to actually ship **PyTorch 2.4.1+cu124**
- B200 GPUs (compute capability sm_100) to be **completely unusable** since PyTorch 2.4.1 only supports up to sm_90
- Users paying for GPU time they cannot use

## Evidence

Three separate GitHub issues report problems with the same PyTorch 2.8.0 template:

- **#114**: PyTorch 2.8.0 cu128 template installs 2.4.1 (root cause analysis with `docker-bake.hcl` line reference)
- **#98** (Aug 2025): Same template fails to start with `unsatisfied condition: cuda>=12.8`
- **#101** (Oct 2025): Same template has SSH errors and broken vLLM downloads across A40 and RTX 5090

Additionally, two RunPod support tickets (#35283, #35526) report related template issues. Support responses have attributed the problem to user-side CUDA configuration or datacenter hardware variance, but the root cause is in the build pipeline.

## Fix

A post-install `RUN` step that:

1. Extracts the expected torch version from the `TORCH` build arg
2. Checks the actually installed version via `import torch`
3. **Fails the build with a clear error message** if they don't match

```dockerfile
RUN EXPECTED_TORCH=$(echo "${TORCH}" | grep -oP 'torch==\K[0-9]+\.[0-9]+\.[0-9]+') && \
    INSTALLED_TORCH=$(python -c "import torch; print(torch.__version__.split('+')[0])") && \
    if [ "$EXPECTED_TORCH" != "$INSTALLED_TORCH" ]; then \
        echo "ERROR: PyTorch version mismatch!" >&2; \
        echo "  Expected: ${EXPECTED_TORCH}" >&2; \
        echo "  Installed: ${INSTALLED_TORCH}" >&2; \
        echo "  Wheel source: cu${WHEEL_SRC}" >&2; \
        echo "  Check that wheels exist at: https://download.pytorch.org/whl/cu${WHEEL_SRC}/torch/" >&2; \
        exit 1; \
    fi
```

## Current wheel availability (verified April 2, 2026)

| torch | cu124 | cu126 | cu128 | cu129 | cu130 |
|-------|-------|-------|-------|-------|-------|
| 2.8.0 | No | Yes | Yes | Yes | No |
| 2.9.0 | - | - | Yes | Yes | Yes |
| 2.9.1 | - | - | Yes | Yes | Yes |

The cu128 wheels for torch 2.8.0 **now exist** on the stable index. The `docker-bake.hcl` configuration is correct today, but the published Docker images were built when those wheels were missing. A rebuild with this verification step will both fix the current images and prevent this class of bug from recurring.

## Notes

- Zero additional build time for correct configurations (verification is instant)
- For broken configurations, the build fails fast with an actionable error instead of publishing a silently broken image
- The `docker-bake.hcl` does not need changes since the cu128 wheels now exist; a rebuild is sufficient
- The cu130/torch 2.8.0 row correctly uses `whl_src = "129"` since cu130 wheels don't exist for 2.8.0

Fixes #114
Related: #98, #101