### PR TITLE
fix: add PyTorch version verification with hardened error handling

### DIFF
--- a/official-templates/pytorch/Dockerfile
+++ b/official-templates/pytorch/Dockerfile
@@ -5,3 +5,18 @@ ARG WHEEL_SRC
 ARG TORCH
 
 RUN python -m pip install --resume-retries 3 --no-cache-dir --upgrade ${TORCH} --index-url https://download.pytorch.org/whl/cu${WHEEL_SRC}
+
+# Verify that the installed torch version matches what was requested.
+# pip silently falls back to older versions when wheels are missing from an index,
+# which has caused B200 GPUs to be unusable (sm_100 not supported by older PyTorch).
+# See: https://github.com/runpod/containers/issues/114
+RUN EXPECTED_TORCH=$(echo "${TORCH}" | grep -oP 'torch==\K[0-9]+\.[0-9]+\.[0-9]+') && \
+    INSTALLED_TORCH=$(python -c "import torch; print(torch.__version__.split('+')[0])") && \
+    if [ "$EXPECTED_TORCH" != "$INSTALLED_TORCH" ]; then \
+        echo "ERROR: PyTorch version mismatch!" >&2; \
+        echo "  Expected: ${EXPECTED_TORCH}" >&2; \
+        echo "  Installed: ${INSTALLED_TORCH}" >&2; \
+        echo "  Wheel source: cu${WHEEL_SRC}" >&2; \
+        echo "  Check that wheels exist at: https://download.pytorch.org/whl/cu${WHEEL_SRC}/torch/" >&2; \
+        exit 1; \
+    fi

--- a/official-templates/pytorch/Dockerfile
+++ b/official-templates/pytorch/Dockerfile
@@ -10,8 +10,22 @@ RUN python -m pip install --resume-retries 3 --no-cache-dir --upgrade ${TORCH} -
 # pip silently falls back to older versions when wheels are missing from an index,
 # which has caused B200 GPUs to be unusable (sm_100 not supported by older PyTorch).
 # See: https://github.com/runpod/containers/issues/114
-RUN EXPECTED_TORCH=$(echo "${TORCH}" | grep -oP 'torch==\K[0-9]+\.[0-9]+\.[0-9]+') && \
-    INSTALLED_TORCH=$(python -c "import torch; print(torch.__version__.split('+')[0])") && \
+RUN EXPECTED_TORCH=$(echo "${TORCH}" | grep -oP '\btorch==\K[0-9]+\.[0-9]+\.[0-9]+' | head -1) || { \
+        echo "ERROR: Could not extract torch version from TORCH='${TORCH}'" >&2; \
+        exit 1; \
+    } && \
+    [ -n "$EXPECTED_TORCH" ] || { \
+        echo "ERROR: Extracted torch version is empty from TORCH='${TORCH}'" >&2; \
+        exit 1; \
+    } && \
+    INSTALLED_TORCH=$(python -c "import torch; print(torch.__version__.split('+')[0])") || { \
+        echo "ERROR: Failed to determine installed torch version — torch may not be installed." >&2; \
+        exit 1; \
+    } && \
+    [ -n "$INSTALLED_TORCH" ] || { \
+        echo "ERROR: Installed torch version string is empty." >&2; \
+        exit 1; \
+    } && \
     if [ "$EXPECTED_TORCH" != "$INSTALLED_TORCH" ]; then \
         echo "ERROR: PyTorch version mismatch!" >&2; \
         echo "  Expected: ${EXPECTED_TORCH}" >&2; \


### PR DESCRIPTION
## Summary

- Adds build-time verification that the installed PyTorch version matches the requested version, preventing pip from silently falling back to older versions
- Hardens all failure paths with explicit, actionable error messages

Based on the excellent work by @dentity007 in #115. Their original commit is preserved in this branch.

## Problem

pip silently falls back to older PyTorch versions when wheels are missing from a CUDA-specific index. This caused the `runpod/pytorch:1.0.2-cu1281-torch280-ubuntu2404` template to ship PyTorch 2.4.1 instead of 2.8.0, making B200 GPUs (sm_100) completely unusable.

See #114, #98, #101 for user reports.

## Changes

1. **Version verification** (from #115): Post-install RUN step extracts expected torch version from the `TORCH` build arg, compares against `torch.__version__`, and fails the build on mismatch
2. **Hardened error handling**: Every failure path now produces a clear, actionable error message instead of opaque exit codes:
   - grep extraction failure → reports the TORCH arg value
   - Empty extracted version → reports the TORCH arg value
   - torch import failure → tells user to check pip output
   - Empty installed version → explicit error
   - Version mismatch → reports expected, installed, wheel source, and check URL
3. **Defensive regex**: Word-boundary anchor (`\b`) and `head -1` to future-proof extraction

## Test plan

- [ ] Build a pytorch image with valid TORCH arg — verify it succeeds
- [ ] Build with intentionally wrong wheel source — verify mismatch error with all fields populated
- [ ] Build with empty TORCH arg — verify clear "could not extract" error
- [ ] Rebuild existing cu128/torch280 matrix entry — verify it now succeeds (wheels exist)

Fixes #114
Supersedes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)