### PR TITLE
chore: correct brand casing to Runpod in docs

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
-# Smoke tests for RunPod container images
+# Smoke tests for Runpod container images
 
-Spins up each image on a real RunPod pod, waits for it to stay healthy
+Spins up each image on a real Runpod pod, waits for it to stay healthy
 for `DWELL_SEC` seconds, runs an image-appropriate functional check
 (CUDA / `nvidia-smi` / `torch.cuda` / optional JupyterLab), then
 terminates the pod. Designed to catch the failure modes that **only
@@ -43,7 +43,7 @@ tests/
    The API key needs **pod-management** permissions. You can find /
    generate one at <https://www.runpod.io/console/user/settings>.
 
-3. **SSH key registered on your RunPod account.** `test_images.py`
+3. **SSH key registered on your Runpod account.** `test_images.py`
    probes every pod over SSH for the real readiness signal and the
    GPU/CUDA functional check. `runpodctl` writes a managed key pair on
    first use; if you already have one in `~/.runpod/ssh/` you're set.
@@ -52,7 +52,7 @@ tests/
    <https://www.runpod.io/console/user/settings#ssh-keys>.
 
 4. **(Recommended)** A Docker Hub registry auth registered with
-   `runpodctl registry add`. RunPod datacenters share an anonymous Hub
+   `runpodctl registry add`. Runpod datacenters share an anonymous Hub
    IP pool that hits the `toomanyrequests` rate limit fast — without
    auth, parallel runs in particular will produce a wave of
    "image pull backoff" failures that look like image bugs but aren't.
@@ -135,8 +135,8 @@ The granular per-pod outcomes below collapse into them:
 | `PASS` | `PASS` | Image booted, all checks passed, survived dwell. | nothing |
 | `FAIL` | `FAIL` | Pod was created and the container itself proved broken (CUDA check failed, JupyterLab didn't start, crashed during dwell, etc.). Moving to another GPU won't help — the image is the problem. | fix the image |
 | `FAIL` | `CREATE_FAIL` | Pod-create returned a non-capacity, non-transient orchestrator error (bad image tag, registry auth, malformed request, missing CUDA version). | fix the manifest / image ref / auth |
-| `SKIP` | all `UNAVAILABLE` | RunPod had no capacity on **any** candidate instance type. | retry later, expand `instances:` list, or raise `max_price_per_hour` |
-| `SKIP` | some `STUCK` + rest `UNAVAILABLE` | At least one instance was scheduled but RunPod never assigned an SSH endpoint within `CREATE_TIMEOUT` (slow pull / dead host). | retry later — usually transient |
+| `SKIP` | all `UNAVAILABLE` | Runpod had no capacity on **any** candidate instance type. | retry later, expand `instances:` list, or raise `max_price_per_hour` |
+| `SKIP` | some `STUCK` + rest `UNAVAILABLE` | At least one instance was scheduled but Runpod never assigned an SSH endpoint within `CREATE_TIMEOUT` (slow pull / dead host). | retry later — usually transient |
 
 `FAIL` always exits `1`. `SKIP` is governed by `ON_SKIP` (env-var) /
 `on-skip` (CI input), one of:
@@ -237,7 +237,7 @@ Field reference:
 The `base_cpu` group is special: `runpodctl` 2.3.0 does not let us pick
 a specific CPU flavor (`--gpu-id` is rejected for `--compute-type CPU`),
 so the manifest needs ONLY an `images:` list for that group — no
-`instances:` / `max_price_per_hour:` / `min_vram_gb:`. RunPod picks a
+`instances:` / `max_price_per_hour:` / `min_vram_gb:`. Runpod picks a
 CPU flavor for us.
 
 
@@ -324,7 +324,7 @@ pytorch:
 |---|---|---|
 | `CLOUD_TYPE` | `SECURE` | `SECURE` or `COMMUNITY`. |
 | `DISK_GB` | `100` | Container disk size for GPU pods. |
-| `CPU_DISK_GB` | `20` | Container disk size for CPU pods. RunPod caps this per CPU flavor (20 GB on the cheapest, 30 GB on larger ones); 20 is the universal safe value. |
+| `CPU_DISK_GB` | `20` | Container disk size for CPU pods. Runpod caps this per CPU flavor (20 GB on the cheapest, 30 GB on larger ones); 20 is the universal safe value. |
 | `CPU_CANDIDATES` | `""` (uses `cpu-secure,cpu-community`) | CPU "instance candidates". `runpodctl pod create` doesn't accept `--vcpu` / `--mem` / `--cpu-flavor`, so we vary the axes it DOES expose for CPU: `--cloud-type` (SECURE vs COMMUNITY) and optional `--data-center-ids`. Each label becomes one candidate iterated by the same per-instance retry loop GPU groups use, so when SECURE is saturated COMMUNITY almost always has free CPU capacity. Format: `label:CLOUD[:DC1+DC2+…],label:CLOUD[:DC_CSV],…` (use `+` not `,` to separate DC ids inside one candidate so the outer csv stays unambiguous). CLOUD must be SECURE or COMMUNITY. Malformed entries are silently dropped; an empty/all-broken value falls back to the default 2-candidate list. |
 | `RUNPOD_API_KEY` | _(from `~/.runpod/config.toml`)_ | Used for the GraphQL GPU pricing query. Set this in CI / containers without a config file. |
 | `REGISTRY_AUTH_ID` | _(empty)_ | Explicit Docker Hub registry auth id to pass as `--registry-auth-id`. Overrides auto-discovery. |
@@ -332,14 +332,14 @@ pytorch:
 | `DWELL_SEC` | `60` | Extra seconds to wait after SSH becomes reachable, then re-probe SSH to catch containers that boot, accept SSH, then crash. Set 0 to skip the re-probe. |
 | `CREATE_TIMEOUT` | `600` | Max seconds to wait for SSH to become reachable. Raise for ROCm workflows (`create-timeout: "1200"` on the action) — the official `rocm/pytorch:*` base images are 30-50GB and routinely take 8-15 minutes to pull. |
 | `POLL_INTERVAL` | `10` | Poll cadence for SSH probes. |
-| `MAX_PARALLEL` | `1` | How many images to smoke-test concurrently. Each worker holds at most one pod, so this caps simultaneous live pods. Keep modest to avoid RunPod rate limits and surprise bills. |
-| `CREATE_RETRIES` | `3` | Retry pod-create up to N times on transient RunPod 5xx errors (`Something went wrong`, 502/503). Capacity shortages are NOT retried. |
+| `MAX_PARALLEL` | `1` | How many images to smoke-test concurrently. Each worker holds at most one pod, so this caps simultaneous live pods. Keep modest to avoid Runpod rate limits and surprise bills. |
+| `CREATE_RETRIES` | `3` | Retry pod-create up to N times on transient Runpod 5xx errors (`Something went wrong`, 502/503). Capacity shortages are NOT retried. |
 | `CREATE_RETRY_BACKOFF` | `10` | Seconds between retries (linear backoff). |
 | `STALL_HINT_AFTER` | `180` | Seconds without an SSH endpoint before the script prints a hint about slow pulls / possible Docker Hub rate limit. |
 | `SSH_LOG_FETCH` | `1` | `1`/`0` — fetch container logs via direct SSH at PASS/FAIL. |
 | `RUNPOD_SSH_KEY` | _(empty)_ | Path to private key matching the `PUBLIC_KEY` `runpodctl` injects into pods. Auto-discovered from common locations if not set. |
 | `JUPYTER_WAIT_TIMEOUT` | `30` | Seconds the in-pod Jupyter probe waits for `:8888` to bind. |
-| `JUPYTER_PROXY_TIMEOUT` | `60` | Seconds the proxy probe retries while RunPod's ingress registers the new pod. |
+| `JUPYTER_PROXY_TIMEOUT` | `60` | Seconds the proxy probe retries while Runpod's ingress registers the new pod. |
 
 
 ## Functional check
@@ -380,7 +380,7 @@ Two stages, both must pass:
    Catches port-type misconfigurations (`8888/tcp` instead of
    `8888/http` — the proxy never wires up non-http ports) and DNS /
    proxy registration issues that would prevent real users from
-   reaching Jupyter from the RunPod console.
+   reaching Jupyter from the Runpod console.
 
 
 ## Running in CI
@@ -391,7 +391,7 @@ wraps everything in this script needs for a clean CI run:
 
 1. Installs the pinned `runpodctl` binary (`runpodctl-version`,
    `runpodctl-sha256` inputs).
-2. Configures the RunPod API key (`runpod-api-key` input) into
+2. Configures the Runpod API key (`runpod-api-key` input) into
    `~/.runpod/config.toml`.
 3. Writes the `ssh-private-key` input to `~/.ssh/id_runpod` and exports
    `RUNPOD_SSH_KEY` so the in-pod CUDA probe and log fetch work.
@@ -436,12 +436,12 @@ fields.
 | every group says `no capacity on any of N candidate instance type(s)` | budget too low / VRAM too high / region saturated | raise `max_price_per_hour`, drop `min_vram_gb`, or set explicit `instances:` |
 | only the `base_cpu` group says `no capacity` while GPU groups pass | the cloud(s) you target don't have CPU capacity right now | by default we already try SECURE then COMMUNITY. If both are full, add DC-pinned candidates: `CPU_CANDIDATES="cpu-secure:SECURE,cpu-community:COMMUNITY,cpu-eu:COMMUNITY:EU-RO-1+EU-NL-1,cpu-us:COMMUNITY:US-OR-1"` |
 | pod stays in `ssh endpoint not assigned yet` past `STALL_HINT_AFTER` | slow image pull or Docker Hub `toomanyrequests` | add registry auth, reduce `MAX_PARALLEL`, or wait 6 h for the Hub rate limit to reset |
-| `ssh_probe=FAIL — Permission denied (publickey)` | wrong SSH key | export `RUNPOD_SSH_KEY=/path/to/private/key` whose public half is on the RunPod account |
+| `ssh_probe=FAIL — Permission denied (publickey)` | wrong SSH key | export `RUNPOD_SSH_KEY=/path/to/private/key` whose public half is on the Runpod account |
 | `pod entered TIMEOUT state` repeatedly on Blackwell GPUs for a `pytorch` group | PyTorch ≤ 2.6 has no `sm_100`/`sm_120` kernels | add `exclude_instances: ["*Blackwell*"]` to the group |
 | `nvidia-container-cli: requirement error: unsatisfied condition: cuda>=X.Y` in pod logs | image needs a newer driver than the host has | set `min_cuda_version: "X.Y"` in the manifest (only needed for tags without a `cuXYZW`/`cudaXYZW` marker) |
 | `jupyter check (in-pod) FAILED -- start.sh did not bring up JupyterLab` | `start.sh` is launching Jupyter with the wrong Python interpreter (classic Ubuntu 22.04 `python3` → 3.10 vs `python` → 3.12) | fix `container-template/start.sh` to use `python -m jupyter lab` |
 | `jupyter check (public proxy) FAILED` but in-pod check passed | port exposed as `8888/tcp` instead of `8888/http`, OR proxy hasn't registered the pod yet | check `pod create --ports` arg; bump `JUPYTER_PROXY_TIMEOUT` if proxy is just slow |
-| script hangs at `Cleaning up N leftover pod(s)…` | RunPod API is slow to respond to delete | wait it out; `--terminate-after` (~2 h) is the backstop and will kill anything we missed |
+| script hangs at `Cleaning up N leftover pod(s)…` | Runpod API is slow to respond to delete | wait it out; `--terminate-after` (~2 h) is the backstop and will kill anything we missed |
 
 
 ## Exit code
@@ -450,7 +450,7 @@ fields.
 `ON_SKIP ∈ {warn, pass}`. `1` if any image FAILed (broken container —
 always fatal), or if any image SKIPped under the default `ON_SKIP=fail`.
 
-SKIPs mean the smoke test never actually ran on the image (RunPod had no
+SKIPs mean the smoke test never actually ran on the image (Runpod had no
 capacity on every candidate, or every candidate landed on a stuck host)
 — that's effectively zero validation, so the default is strict.
 Override with:


### PR DESCRIPTION
Corrects the brand casing of the company name in documentation: `RunPod` -> `Runpod`.

The company name is **Runpod** (capital R, lowercase p). `RunPod` was the official styling before the June 2025 rebrand, which is why it lingers across older docs.

### Scope
Markdown/MDX prose only. Deliberately **not** touched:
- Code identifiers (`RunPodClient`, `RunPodLogger`, `ChatRunPod`, `RunPodProvider`, ...)
- Anything inside fenced code blocks or inline `code` spans
- URLs (including `reddit.com/r/RunPod`, whose path cannot be renamed)
- Env vars (`RUNPOD_API_KEY`) and literal identifiers like `RunPod-Key-Go`

No code, behavior, or public API changes. Docs text only.

### Why it matters beyond tidiness
READMEs and docs are heavily crawled and are a large share of what LLMs and answer engines ingest about Runpod. Consistent casing at the source is how the correct spelling propagates into AI-generated answers over time.

Part of a company-wide brand-casing sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)